### PR TITLE
Bump k8-client to v3.0.0 and k8-config to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "k8-config"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "dirs",
  "hostfile",

--- a/src/k8-client/Cargo.toml
+++ b/src/k8-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-client"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Core Kubernetes metadata traits"
 repository = "https://github.com/infinyon/k8-api"
@@ -36,7 +36,7 @@ k8-obj-core = { version = "1.1.0", path = "../k8-obj-core"}
 k8-obj-metadata = { version = "1.0.0", path = "../k8-obj-metadata" }
 k8-metadata-client = { version = "1.0.0", path = "../k8-metadata-client"}
 k8-diff = { version = "0.1.0", path = "../k8-diff"}
-k8-config = { version = "1.0.0", path = "../k8-config"}
+k8-config = { version = "2.0.0", path = "../k8-config"}
 thiserror = "1.0.20"
 
 [dev-dependencies]

--- a/src/k8-config/Cargo.toml
+++ b/src/k8-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8-config"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 description = "Read Kubernetes config"


### PR DESCRIPTION
When #17 was merged, I forgot to include version bumps to the crates. Unfortunately changing the public error types caused a breaking change, so k8-client and k8-config both need major version bumps.