### PR TITLE
Do not ignore the owner_references attribute while using as_input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/k8-types/Cargo.toml
+++ b/src/k8-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-types"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Kubernetes Object Types"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-types/src/metadata.rs
+++ b/src/k8-types/src/metadata.rs
@@ -137,6 +137,7 @@ impl ObjectMeta {
         InputObjectMeta {
             name: self.name.clone(),
             namespace: self.namespace.clone(),
+            owner_references: self.owner_references.clone(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
When we run  K8Obj as_input we lost the owner_reference of that object, this fixes that.

This line is where as_input is call for the metadata

https://github.com/infinyon/k8-api/blob/80b9008ebaefc9e7ff8edfc3660ce148e9f050f3/src/k8-types/src/metadata.rs#L386

Resolves #64