### PR TITLE
[Merged by Bors] - Allow deserializing without resource_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/k8-types/Cargo.toml
+++ b/src/k8-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-types"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Kubernetes Object Types"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-types/src/metadata.rs
+++ b/src/k8-types/src/metadata.rs
@@ -44,6 +44,7 @@ pub struct ObjectMeta {
     pub uid: String,
     pub creation_timestamp: String,
     pub generation: Option<i32>,
+    #[serde(default)]
     pub resource_version: String,
     // optional
     pub cluster_name: Option<String>,
@@ -629,6 +630,7 @@ where
 #[serde(rename_all = "camelCase")]
 pub struct ListMetadata {
     pub _continue: Option<String>,
+    #[serde(default)]
     pub resource_version: String,
 }
 


### PR DESCRIPTION
Allow fetching resources which don't have a `resource_version` in metadata. Apparently `resource_version` is not required.

This is needed for fetching `PodMetrics` from [metrics-server](https://github.com/kubernetes-sigs/metrics-server).