### PR TITLE
[Merged by Bors] - feat: Use IntOrString for  maxUnavailable and maxSurge in RollingUpdateDeployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.7.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "k8-config"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "dirs",
  "fluvio-future",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "k8-metadata-client"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/k8-client/Cargo.toml
+++ b/src/k8-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-client"
-version = "7.0.0"
+version = "7.0.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Core Kubernetes metadata traits"
 repository = "https://github.com/infinyon/k8-api"
@@ -37,7 +37,7 @@ fluvio-future = { version="0.3.15", features=["net", "task"] }
 k8-metadata-client = { version="4.0.0", path="../k8-metadata-client" } 
 k8-diff = { version="0.1.0", path="../k8-diff" }
 k8-config = { version="2.0.0", path="../k8-config" }
-k8-types = { version="0.6.0", path="../k8-types", features=["core", "batch"] }
+k8-types = { version="0.7.0", path="../k8-types", features=["core", "batch"] }
 
 
 [dev-dependencies]

--- a/src/k8-client/Cargo.toml
+++ b/src/k8-client/Cargo.toml
@@ -37,7 +37,7 @@ fluvio-future = { version="0.3.15", features=["net", "task"] }
 k8-metadata-client = { version="4.0.0", path="../k8-metadata-client" } 
 k8-diff = { version="0.1.0", path="../k8-diff" }
 k8-config = { version="2.0.0", path="../k8-config" }
-k8-types = { version="0.7.0", path="../k8-types", features=["core", "batch"] }
+k8-types = { version="0.6.1", path="../k8-types", features=["core", "batch"] }
 
 
 [dev-dependencies]

--- a/src/k8-client/k8-test/hello-deploy.yaml
+++ b/src/k8-client/k8-test/hello-deploy.yaml
@@ -21,4 +21,8 @@ spec:
             - name: RUST_LOG
               value: debug
           command: ["/hello"]
-  
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 25%

--- a/src/k8-client/src/client/client_impl.rs
+++ b/src/k8-client/src/client/client_impl.rs
@@ -47,7 +47,7 @@ pub struct K8Client {
     token: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct VersionInfo {
     pub major: String,

--- a/src/k8-config/Cargo.toml
+++ b/src/k8-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8-config"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 description = "Read Kubernetes config"

--- a/src/k8-config/src/config.rs
+++ b/src/k8-config/src/config.rs
@@ -9,13 +9,13 @@ use serde_json::Value;
 
 use crate::ConfigError;
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 pub struct Cluster {
     pub name: String,
     pub cluster: ClusterDetail,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ClusterDetail {
     pub insecure_skip_tls_verify: Option<bool>,
@@ -30,13 +30,13 @@ impl ClusterDetail {
     }
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 pub struct Context {
     pub name: String,
     pub context: ContextDetail,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 pub struct ContextDetail {
     pub cluster: String,
     pub user: String,
@@ -52,7 +52,7 @@ impl ContextDetail {
     }
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 pub struct User {
     pub name: String,
     pub user: UserDetail,
@@ -64,7 +64,7 @@ pub struct User {
 //    pub config: HashMap<String, String>,
 //}
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 #[serde(tag = "name", content = "config")]
 pub enum AuthProviderDetail {
     #[serde(alias = "gcp")]
@@ -101,7 +101,7 @@ impl AuthProviderDetail {
     }
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct GcpAuthProviderConfig {
     pub access_token: Option<String>,
@@ -123,7 +123,7 @@ pub struct GcpAuthProviderConfig {
 //    refresh_token: String,
 //}
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct UserDetail {
     pub auth_provider: Option<AuthProviderDetail>,
@@ -137,7 +137,7 @@ pub struct UserDetail {
     pub password: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Exec {
     #[serde(rename = "apiVersion")]
@@ -146,7 +146,7 @@ pub struct Exec {
     pub command: String,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct KubeConfig {
     #[serde(rename = "apiVersion")]

--- a/src/k8-metadata-client/Cargo.toml
+++ b/src/k8-metadata-client/Cargo.toml
@@ -15,4 +15,4 @@ serde = { version ="1.0.136", features = ['derive'] }
 serde_json = "1.0.40"
 async-trait = "0.1.52"
 k8-diff = { version = "0.1.0", path = "../k8-diff"}
-k8-types = { version = "0.7.0", path = "../k8-types" }
+k8-types = { version = "0.6.1", path = "../k8-types" }

--- a/src/k8-metadata-client/Cargo.toml
+++ b/src/k8-metadata-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-metadata-client"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Trait for interfacing kubernetes metadata service"
 repository = "https://github.com/infinyon/k8-api"
@@ -15,4 +15,4 @@ serde = { version ="1.0.136", features = ['derive'] }
 serde_json = "1.0.40"
 async-trait = "0.1.52"
 k8-diff = { version = "0.1.0", path = "../k8-diff"}
-k8-types = { version = "0.6.0", path = "../k8-types" }
+k8-types = { version = "0.7.0", path = "../k8-types" }

--- a/src/k8-types/Cargo.toml
+++ b/src/k8-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-types"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Kubernetes Object Types"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-types/Cargo.toml
+++ b/src/k8-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-types"
-version = "0.7.0"
+version = "0.6.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Kubernetes Object Types"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-types/src/app/deployment.rs
+++ b/src/k8-types/src/app/deployment.rs
@@ -13,7 +13,7 @@ const DEPLOYMENT_API: Crd = Crd {
     },
 };
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct DeploymentSpec {
     pub min_ready_seconds: Option<i32>,
@@ -26,7 +26,7 @@ pub struct DeploymentSpec {
     pub template: TemplateSpec<PodSpec>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct DeploymentStrategy {
     pub rolling_update: Option<RollingUpdateDeployment>,
@@ -34,7 +34,7 @@ pub struct DeploymentStrategy {
     pub type_: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct RollingUpdateDeployment {
     pub max_surge: Option<Int32OrString>,
@@ -50,7 +50,7 @@ impl Spec for DeploymentSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DeploymentStatus {
     pub available_replicas: Option<i32>,
@@ -64,7 +64,7 @@ pub struct DeploymentStatus {
     pub updated_replicas: Option<i32>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DeploymentCondition {
     pub last_transition_time: Option<String>,

--- a/src/k8-types/src/app/deployment.rs
+++ b/src/k8-types/src/app/deployment.rs
@@ -2,8 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::pod::PodSpec;
-use crate::{Crd, CrdNames, DefaultHeader, LabelSelector, Spec, Status, TemplateSpec};
-
+use crate::{Crd, CrdNames, DefaultHeader, Int32OrString, LabelSelector, Spec, Status, TemplateSpec};
 const DEPLOYMENT_API: Crd = Crd {
     group: "apps",
     version: "v1",
@@ -38,8 +37,8 @@ pub struct DeploymentStrategy {
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct RollingUpdateDeployment {
-    pub max_surge: Option<String>,
-    pub max_unavailable: Option<String>,
+    pub max_surge: Option<Int32OrString>,
+    pub max_unavailable: Option<Int32OrString>,
 }
 
 impl Spec for DeploymentSpec {

--- a/src/k8-types/src/app/stateful.rs
+++ b/src/k8-types/src/app/stateful.rs
@@ -14,7 +14,7 @@ const STATEFUL_API: Crd = Crd {
     },
 };
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct StatefulSetSpec {
     pub pod_management_policy: Option<PodMangementPolicy>,
@@ -41,26 +41,26 @@ impl Spec for StatefulSetSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct StatefulSetUpdateStrategy {
     pub _type: String,
     pub rolling_ipdate: Option<RollingUpdateStatefulSetStrategy>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RollingUpdateStatefulSetStrategy {
     partition: u32,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 pub enum PodMangementPolicy {
     OrderedReady,
     Parallel,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistentVolumeClaim {
     pub access_modes: Vec<VolumeAccessMode>,
@@ -68,24 +68,24 @@ pub struct PersistentVolumeClaim {
     pub resources: ResourceRequirements,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 pub enum VolumeAccessMode {
     ReadWriteOnce,
     ReadWrite,
     ReadOnlyMany,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct ResourceRequirements {
     pub requests: VolumeRequest,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct VolumeRequest {
     pub storage: String,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct StatefulSetStatus {
     pub replicas: u16,
@@ -102,14 +102,14 @@ pub struct StatefulSetStatus {
 
 impl Status for StatefulSetStatus {}
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 pub enum StatusEnum {
     True,
     False,
     Unknown,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct StatefulSetCondition {
     pub message: String,

--- a/src/k8-types/src/core/namespace.rs
+++ b/src/k8-types/src/core/namespace.rs
@@ -34,7 +34,7 @@ impl Spec for NamespaceSpec {
 
 default_store_spec!(NamespaceSpec, NamespaceStatus, "Namespace");
 
-#[derive(Deserialize, Serialize, PartialEq, Debug, Default, Clone)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NamespaceStatus {
     pub phase: String,

--- a/src/k8-types/src/core/node.rs
+++ b/src/k8-types/src/core/node.rs
@@ -27,14 +27,14 @@ impl Spec for NodeSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NodeSpec {
     #[serde(rename = "providerID")]
     pub provider_id: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NodeStatus {
     pub addresses: Vec<NodeAddress>,
@@ -46,11 +46,11 @@ pub struct NodeStatus {
 
 impl Status for NodeStatus {}
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NodeList {}
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NodeAddress {
     pub address: String,

--- a/src/k8-types/src/core/pod.rs
+++ b/src/k8-types/src/core/pod.rs
@@ -30,7 +30,7 @@ impl Spec for PodSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct PodSpec {
     pub volumes: Vec<VolumeSpec>,
@@ -46,7 +46,7 @@ pub struct PodSpec {
     pub node_selector: Option<HashMap<String, String>>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub enum PodRestartPolicy {
     Always,
     Never,
@@ -58,7 +58,7 @@ impl Default for PodRestartPolicy {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct PodSecurityContext {
     pub fs_group: Option<u32>,
@@ -68,14 +68,14 @@ pub struct PodSecurityContext {
     pub sysctls: Vec<Sysctl>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Sysctl {
     pub name: String,
     pub value: String,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ContainerSpec {
     pub name: String,
@@ -93,7 +93,7 @@ pub struct ContainerSpec {
     pub liveness_probe: Option<Probe>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub enum ImagePullPolicy {
     Always,
     Never,
@@ -106,7 +106,7 @@ impl Default for ImagePullPolicy {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Probe {
     pub exec: Option<ExecAction>,
@@ -118,27 +118,27 @@ pub struct Probe {
     pub timeout_seconds: Option<u32>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ExecAction {
     pub command: Vec<String>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct TcpSocketAction {
     pub host: String,
     pub port: u16,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ResourceRequirements {
     pub limits: DynamicObject,
     pub requests: DynamicObject,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ContainerPortSpec {
     pub container_port: u16,
@@ -156,7 +156,7 @@ impl ContainerPortSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeSpec {
     pub name: String,
@@ -165,7 +165,7 @@ pub struct VolumeSpec {
     pub persistent_volume_claim: Option<PersistentVolumeClaimVolumeSource>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeMount {
     pub mount_path: String,
@@ -175,7 +175,7 @@ pub struct VolumeMount {
     pub sub_path: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretVolumeSpec {
     pub default_mode: u16,
@@ -183,7 +183,7 @@ pub struct SecretVolumeSpec {
     pub optional: Option<bool>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigMapVolumeSource {
     pub default_mode: Option<i32>,
@@ -191,7 +191,7 @@ pub struct ConfigMapVolumeSource {
     pub name: Option<String>,
     pub optional: Option<bool>,
 }
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyToPath {
     pub key: String,
@@ -199,7 +199,7 @@ pub struct KeyToPath {
     pub path: String,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistentVolumeClaimVolumeSource {
     claim_name: String,

--- a/src/k8-types/src/core/secret.rs
+++ b/src/k8-types/src/core/secret.rs
@@ -30,11 +30,11 @@ impl Spec for SecretSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretSpec {}
 
-#[derive(Deserialize, Serialize, Default, PartialEq, Debug, Clone)]
+#[derive(Deserialize, Serialize, Default, Eq, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretStatus {}
 

--- a/src/k8-types/src/core/service.rs
+++ b/src/k8-types/src/core/service.rs
@@ -19,7 +19,7 @@ const SERVICE_API: Crd = Crd {
     },
 };
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ServiceSpec {
     #[serde(rename = "clusterIP")]
@@ -52,7 +52,7 @@ impl Spec for ServiceSpec {
 
 default_store_spec!(ServiceSpec, ServiceStatus, "Service");
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ServicePort {
     pub name: Option<String>,
@@ -61,7 +61,7 @@ pub struct ServicePort {
     pub target_port: Option<TargetPort>,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum TargetPort {
     Number(u16),
@@ -77,7 +77,7 @@ impl std::fmt::Display for TargetPort {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ServiceStatus {
     pub load_balancer: LoadBalancerStatus,
@@ -85,13 +85,13 @@ pub struct ServiceStatus {
 
 impl Status for ServiceStatus {}
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 pub enum ExternalTrafficPolicy {
     Local,
     Cluster,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 pub enum LoadBalancerType {
     ExternalName,
     #[allow(clippy::upper_case_acronyms)]
@@ -100,7 +100,7 @@ pub enum LoadBalancerType {
     LoadBalancer,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct LoadBalancerStatus {
     pub ingress: Vec<LoadBalancerIngress>,
@@ -113,7 +113,7 @@ impl LoadBalancerStatus {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LoadBalancerIngress {
     pub hostname: Option<String>,

--- a/src/k8-types/src/int_or_string.rs
+++ b/src/k8-types/src/int_or_string.rs
@@ -115,3 +115,34 @@ impl serde::Serialize for Int32OrString {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+
+    use serde_json::json;
+
+    use crate::Int32OrString;
+
+    #[test]
+    fn test_int_serde() {
+        let int_value = json!(100);
+
+        let int_or_string: Int32OrString =
+            serde_json::from_value(int_value.clone()).expect("failed deserialization");
+        assert_eq!(int_or_string, Int32OrString::Int(100));
+        let serialization = serde_json::to_value(&int_or_string).expect("failed serialization");
+        assert_eq!(int_value, serialization);
+    }
+
+    #[test]
+    fn test_str_serde() {
+        let str_value = json!("25%");
+
+        let int_or_string: Int32OrString =
+            serde_json::from_value(str_value.clone()).expect("failed deserialization");
+        assert_eq!(int_or_string, Int32OrString::String("25%".into()));
+
+        let serialization = serde_json::to_value(&int_or_string).expect("failed serialization");
+        assert_eq!(str_value, serialization);
+    }
+}

--- a/src/k8-types/src/int_or_string.rs
+++ b/src/k8-types/src/int_or_string.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, convert::Infallible};
 
 /// See: https://github.com/kubernetes/apimachinery/blob/master/pkg/util/intstr/intstr.go
-/// IntOrString is a type that can hold an int32 or a string.
+/// Int32OrString is a type that can hold an int32 or a string.
 /// When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.
 /// This allows you to have, for example, a JSON field that can accept a name or number.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -42,7 +42,7 @@ impl<'de> serde::Deserialize<'de> for Int32OrString {
             type Value = Int32OrString;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(formatter, "enum IntOrString")
+                write!(formatter, "enum Int32OrString")
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
@@ -132,6 +132,14 @@ mod test {
         assert_eq!(int_or_string, Int32OrString::Int(100));
         let serialization = serde_json::to_value(&int_or_string).expect("failed serialization");
         assert_eq!(int_value, serialization);
+    }
+
+    #[test]
+    fn test_invalid_float_serde() {
+        let int_value = json!(2.5);
+
+        let _error = serde_json::from_value::<Int32OrString>(int_value)
+            .expect_err("float should not be deserialized");
     }
 
     #[test]

--- a/src/k8-types/src/int_or_string.rs
+++ b/src/k8-types/src/int_or_string.rs
@@ -15,6 +15,21 @@ impl Default for Int32OrString {
         Int32OrString::Int(0)
     }
 }
+impl FromStr for Int32OrString {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<i32>() {
+            Ok(i) => Ok(Int32OrString::Int(i)),
+            Err(_) => Ok(Int32OrString::String(s.to_string())),
+        }
+    }
+}
+
+impl From<i32> for Int32OrString {
+    fn from(f: i32) -> Self {
+        Int32OrString::Int(f)
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for Int32OrString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -86,22 +101,6 @@ impl<'de> serde::Deserialize<'de> for Int32OrString {
         }
 
         deserializer.deserialize_any(Visitor)
-    }
-}
-
-impl FromStr for Int32OrString {
-    type Err = Infallible;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.parse::<i32>() {
-            Ok(i) => Ok(Int32OrString::Int(i)),
-            Err(_) => Ok(Int32OrString::String(s.to_string())),
-        }
-    }
-}
-
-impl From<i32> for Int32OrString {
-    fn from(f: i32) -> Self {
-        Int32OrString::Int(f)
     }
 }
 

--- a/src/k8-types/src/int_or_string.rs
+++ b/src/k8-types/src/int_or_string.rs
@@ -1,0 +1,118 @@
+use std::{str::FromStr, convert::Infallible};
+
+/// See: https://github.com/kubernetes/apimachinery/blob/master/pkg/util/intstr/intstr.go
+/// IntOrString is a type that can hold an int32 or a string.
+/// When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.
+/// This allows you to have, for example, a JSON field that can accept a name or number.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Int32OrString {
+    Int(i32),
+    String(String),
+}
+
+impl Default for Int32OrString {
+    fn default() -> Self {
+        Int32OrString::Int(0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Int32OrString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Int32OrString;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "enum IntOrString")
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Int32OrString::Int(v))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v < i64::from(i32::min_value()) || v > i64::from(i32::max_value()) {
+                    return Err(serde::de::Error::invalid_value(
+                        serde::de::Unexpected::Signed(v),
+                        &"a 32-bit integer",
+                    ));
+                }
+
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                Ok(Int32OrString::Int(v as i32))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                #[allow(clippy::cast_sign_loss)]
+                {
+                    if v > i32::max_value() as u64 {
+                        return Err(serde::de::Error::invalid_value(
+                            serde::de::Unexpected::Unsigned(v),
+                            &"a 32-bit integer",
+                        ));
+                    }
+                }
+
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                Ok(Int32OrString::Int(v as i32))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_string(v.to_string())
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Int32OrString::String(v))
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+impl FromStr for Int32OrString {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<i32>() {
+            Ok(i) => Ok(Int32OrString::Int(i)),
+            Err(_) => Ok(Int32OrString::String(s.to_string())),
+        }
+    }
+}
+
+impl From<i32> for Int32OrString {
+    fn from(f: i32) -> Self {
+        Int32OrString::Int(f)
+    }
+}
+
+impl serde::Serialize for Int32OrString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Int32OrString::Int(i) => i.serialize(serializer),
+            Int32OrString::String(s) => s.serialize(serializer),
+        }
+    }
+}

--- a/src/k8-types/src/lib.rs
+++ b/src/k8-types/src/lib.rs
@@ -1,4 +1,5 @@
 mod crd;
+mod int_or_string;
 mod metadata;
 pub mod options;
 pub mod store;
@@ -75,3 +76,5 @@ mod spec_def {
 
     impl Header for DefaultHeader {}
 }
+
+pub use int_or_string::Int32OrString;

--- a/src/k8-types/src/metadata.rs
+++ b/src/k8-types/src/metadata.rs
@@ -35,7 +35,7 @@ pub trait LabelProvider: Sized {
 
 /// metadata associated with object when returned
 /// here name and namespace must be populated
-#[derive(Deserialize, Serialize, PartialEq, Debug, Default, Clone)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ObjectMeta {
     // mandatory fields
@@ -273,7 +273,7 @@ impl K8Meta for UpdateItemMeta {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct OwnerReferences {
     pub api_version: String,
@@ -521,7 +521,7 @@ impl From<ItemMeta> for InputObjectMeta {
 }
 
 /// name is optional for template
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct TemplateMeta {
     pub name: Option<String>,
@@ -549,7 +549,7 @@ impl TemplateMeta {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TemplateSpec<S> {
     pub metadata: Option<TemplateMeta>,
@@ -634,7 +634,7 @@ pub struct ListMetadata {
     pub resource_version: String,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Default, Debug, Eq, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelSelector {
     pub match_labels: HashMap<String, String>,
@@ -650,7 +650,7 @@ impl LabelSelector {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Env {
     pub name: String,
@@ -680,13 +680,13 @@ impl Env {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct EnvVarSource {
     field_ref: Option<ObjectFieldSelector>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectFieldSelector {
     pub field_path: String,

--- a/src/k8-types/src/store.rs
+++ b/src/k8-types/src/store.rs
@@ -21,7 +21,7 @@ pub trait StoreSpec: Sized + Default + Debug + Clone {
 }
 
 /// Metadata object. Used to be KVObject int sc-core
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct MetaItem<S>
 where
     S: StoreSpec,
@@ -127,7 +127,7 @@ where
     }
 }
 
-#[derive(Default, Debug, PartialEq, Clone)]
+#[derive(Default, Debug, Eq, PartialEq, Clone)]
 pub struct MetaItemContext {
     pub item_ctx: Option<ObjectMeta>,
     pub parent_ctx: Option<ObjectMeta>,
@@ -157,7 +157,7 @@ impl MetaItemContext {
 #[macro_export]
 macro_rules! default_store_spec {
     ($spec:ident,$status:ident,$name:expr) => {
-        impl crate::store::StoreSpec for $spec {
+        impl $crate::store::StoreSpec for $spec {
             const LABEL: &'static str = $name;
 
             type K8Spec = Self;
@@ -166,11 +166,11 @@ macro_rules! default_store_spec {
             type Owner = Self;
 
             fn convert_from_k8(
-                k8_obj: crate::K8Obj<Self::K8Spec>,
-            ) -> Result<Option<crate::store::MetaItem<Self>>, std::io::Error> {
+                k8_obj: $crate::K8Obj<Self::K8Spec>,
+            ) -> Result<Option<$crate::store::MetaItem<Self>>, std::io::Error> {
                 let ctx =
-                    crate::store::MetaItemContext::default().with_ctx(k8_obj.metadata.clone());
-                Ok(Some(crate::store::MetaItem::new(
+                    $crate::store::MetaItemContext::default().with_ctx(k8_obj.metadata.clone());
+                Ok(Some($crate::store::MetaItem::new(
                     k8_obj.metadata.name,
                     k8_obj.spec,
                     k8_obj.status,


### PR DESCRIPTION
These fields can be either a string or an int, we could have serialization issues with the current implementation:

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable

Also clippy issues were fixed