### PR TITLE
[Merged by Bors] - feat: add annotations to TemplateMeta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/src/k8-client/Cargo.toml
+++ b/src/k8-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-client"
-version = "9.0.0"
+version = "10.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Core Kubernetes metadata traits"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-client/Makefile
+++ b/src/k8-client/Makefile
@@ -2,4 +2,6 @@ run-integration-test-native:
 	cargo test test_pods --features k8,native_tls
 	cargo test test_object_conflict --features k8,native_tls
 	cargo test test_object_replace --features k8,native_tls
+	cargo test test_job_created --features k8,native_tls
+	cargo test test_service_changes --features k8,native_tls
 

--- a/src/k8-client/src/error.rs
+++ b/src/k8-client/src/error.rs
@@ -28,7 +28,7 @@ pub enum ClientError {
     PatchError,
     HyperError(HyperError),
     HttpResponse(StatusCode),
-    ApiResponse(MetaStatus),
+    ApiResponse(Box<MetaStatus>),
     Other(String),
     #[cfg(feature = "openssl_tls")]
     Tls(fluvio_future::openssl::TlsError),

--- a/src/k8-client/tests/job.rs
+++ b/src/k8-client/tests/job.rs
@@ -70,7 +70,11 @@ mod integration_tests {
         for job in job_items.items {
             assert_eq!(job.metadata.name, JOB_NAME);
             assert_eq!(
-                job.spec.template.metadata.annotations,
+                job.spec
+                    .template
+                    .metadata
+                    .expect("expected meta")
+                    .annotations,
                 vec![("some-key".to_string(), "some-value".to_string())]
                     .into_iter()
                     .collect(),

--- a/src/k8-types/src/metadata.rs
+++ b/src/k8-types/src/metadata.rs
@@ -526,6 +526,7 @@ pub struct TemplateMeta {
     pub name: Option<String>,
     pub creation_timestamp: Option<String>,
     pub labels: HashMap<String, String>,
+    pub annotations: HashMap<String, String>,
 }
 
 impl LabelProvider for TemplateMeta {


### PR DESCRIPTION
This allows use to define Annotations for pods in Deployments, StatefulSet, Jobs, etc.