### PR TITLE
[Merged by Bors] - feat: add service account spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/k8-types/Cargo.toml
+++ b/src/k8-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-types"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Kubernetes Object Types"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-types/src/core/mod.rs
+++ b/src/k8-types/src/core/mod.rs
@@ -4,4 +4,5 @@ pub mod plugin;
 pub mod pod;
 pub mod secret;
 pub mod service;
+pub mod service_account;
 pub mod node;

--- a/src/k8-types/src/core/service_account.rs
+++ b/src/k8-types/src/core/service_account.rs
@@ -1,0 +1,39 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::default_store_spec;
+use crate::Crd;
+use crate::CrdNames;
+use crate::DefaultHeader;
+use crate::Spec;
+use crate::Status;
+
+const API: Crd = Crd {
+    group: "core",
+    version: "v1",
+    names: CrdNames {
+        kind: "ServiceAccount",
+        plural: "serviceaccounts",
+        singular: "serviceaccount",
+    },
+};
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceAccountSpec {}
+
+impl Spec for ServiceAccountSpec {
+    type Status = ServiceAccountStatus;
+    type Header = DefaultHeader;
+    fn metadata() -> &'static Crd {
+        &API
+    }
+}
+
+default_store_spec!(ServiceAccountSpec, ServiceAccountStatus, "ServiceAccount");
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ServiceAccountStatus {}
+
+impl Status for ServiceAccountStatus {}


### PR DESCRIPTION
Add capability to create `serviceAccount` programatically. Still need to figure it out how to create `Roles` and `RoleBinding` since they don't rely on `Spec`