### PR TITLE
[Merged by Bors] - Use workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "10.0.0"
+version = "10.0.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "src/k8-client",
     "src/k8-ctx-util"
 ]
+
+[workspace.dependencies]
+fluvio-future = "0.5"

--- a/src/k8-client/Cargo.toml
+++ b/src/k8-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-client"
-version = "10.0.0"
+version = "10.0.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Core Kubernetes metadata traits"
 repository = "https://github.com/infinyon/k8-api"
@@ -33,7 +33,7 @@ serde = { version="1.0.136", features=['derive'] }
 serde_json = "1.0.40"
 serde_qs = "0.10.1"
 async-trait = "0.1.52"
-fluvio-future = { version="0.5.0", features=["net", "task"] }
+fluvio-future = { workspace = true, features=["net", "task"] }
 k8-metadata-client = { version="5.1.0", path="../k8-metadata-client" } 
 k8-diff = { version="0.1.0", path="../k8-diff" }
 k8-config = { version="2.0.0", path="../k8-config" }
@@ -45,4 +45,4 @@ rand = "0.8.3"
 once_cell = "1.10.0"
 async-trait = "0.1.52"
 
-fluvio-future = { version="0.5.0", features=["fixture"] }
+fluvio-future = { workspace = true, features=["fixture"] }

--- a/src/k8-config/Cargo.toml
+++ b/src/k8-config/Cargo.toml
@@ -21,7 +21,7 @@ hostfile = "0.2.0"
 thiserror = "1.0.20"
 
 [dev-dependencies]
-fluvio-future = { version = "0.5.0", features = ["subscriber"]}
+fluvio-future = { workspace = true, features = ["subscriber"]}
 
 
 [[example]]


### PR DESCRIPTION
Bump k8-client so we can release it using fluvio-future