### PR TITLE
[Merged by Bors] - feat: Add Serialize to K8Watch

### DIFF
--- a/src/k8-types/Cargo.toml
+++ b/src/k8-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "k8-types"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Kubernetes Object Types"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-types/src/metadata.rs
+++ b/src/k8-types/src/metadata.rs
@@ -613,7 +613,7 @@ pub trait DeserializeWith: Sized {
 }
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", content = "object")]
 #[serde(bound(serialize = "K8Obj<S>: Serialize"))]
 #[serde(bound(deserialize = "K8Obj<S>: DeserializeOwned"))]


### PR DESCRIPTION
it already has the `#[serde(bound(serialize = "K8Obj<S>: Serialize"))]` notation but not being called the Serialize implementation