### PR TITLE
feat: added serialization for k8s config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "k8-config"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "dirs",
  "fluvio-future",

--- a/src/k8-config/Cargo.toml
+++ b/src/k8-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8-config"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Read Kubernetes config"


### PR DESCRIPTION
Added serialization to `K8Config` and an ability to save changes to the original file.

This is needed for adding the embedded k8s context to the kube context file.