### PR TITLE
[Merged by Bors] - feat: impl Display for MetaStatus

### DIFF
--- a/src/k8-types/Cargo.toml
+++ b/src/k8-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "k8-types"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Kubernetes Object Types"
 repository = "https://github.com/infinyon/k8-api"

--- a/src/k8-types/src/metadata.rs
+++ b/src/k8-types/src/metadata.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt;
+use std::fmt::{self, Display};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -331,6 +331,23 @@ pub struct MetaStatus {
     pub status: StatusEnum,
 }
 
+impl Display for MetaStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.status)?;
+
+        if let Some(ref code) = self.code {
+            write!(f, " ({})", code)?;
+        }
+        if let Some(ref message) = self.message {
+            write!(f, ":{}.", message)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for MetaStatus {}
+
 /// Default status implementation
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -339,6 +356,15 @@ pub enum StatusEnum {
     SUCCESS,
     #[serde(rename = "Failure")]
     FAILURE,
+}
+
+impl Display for StatusEnum {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::SUCCESS => write!(f, "Success"),
+            Self::FAILURE => write!(f, "Failure"),
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
and implement `std::error::Error`

This is needed to move crate to use `thiserror`