### PR TITLE
fix: add error visibiliy on cert parsing path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "async-channel"
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "12.0.0"
+version = "12.0.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-anyhow = "1.0.38"
+anyhow = "1.0"
 fluvio-future = "0.6"
 serde_yaml = { version = "0.9.0", default-features = false }

--- a/src/k8-client/Cargo.toml
+++ b/src/k8-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "k8-client"
-version = "12.0.0"
+version = "12.0.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Core Kubernetes metadata traits"
 repository = "https://github.com/infinyon/k8-api"
@@ -39,7 +39,7 @@ serde_qs = "0.12.0"
 serde_yaml = { workspace = true, optional = true }
 async-trait = "0.1.52"
 fluvio-future = { workspace = true, features=["net", "task"] }
-k8-metadata-client = { version="7.0.0", path="../k8-metadata-client" } 
+k8-metadata-client = { version="7.0.0", path="../k8-metadata-client" }
 k8-diff = { version="0.1.0", path="../k8-diff" }
 k8-config = { version="2.2.0", path="../k8-config" }
 k8-types = { version="0.8.5", path="../k8-types", features=["core", "batch"] }

--- a/src/k8-client/src/cert.rs
+++ b/src/k8-client/src/cert.rs
@@ -186,7 +186,19 @@ where
             );
 
             let credential: K8Obj<ExecCredentialSpec> =
-                serde_json::from_slice(&token_output.stdout)?;
+                serde_json::from_slice(&token_output.stdout).map_err(|err| {
+                    let cmd_token = String::from_utf8_lossy(&token_output.stdout).to_string();
+                    IoError::new(
+                        ErrorKind::Other,
+                        format!(
+                            "error parsing credential from: {} {}\nreply: {}\nerr: {}",
+                            exec.command,
+                            exec.args.join(" "),
+                            cmd_token,
+                            err
+                        ),
+                    )
+                })?;
             let token = credential.status.token;
             debug!(?token);
             Ok((builder, Some(token)))


### PR DESCRIPTION
Cert reply parsing can fail w/ a not very expressive error