### PR TITLE
fix: update publish script

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -28,15 +28,6 @@ function check_if_crate_uploaded() {
     fi
 }
 
-
-# We're relying on CARGO_REGISTRY_TOKEN to be set in CI
-function cargo_publish() {
-    cargo publish 2>&1 | tee "$CARGO_OUTPUT_TMP"
-
-    return "${PIPESTATUS[0]}"
-
-}
-
 function cargo_publish_all() {
     # We want to loop though each of the crates and attempt to publish.
 
@@ -44,14 +35,10 @@ function cargo_publish_all() {
     then
         for crate in "${PUBLISH_CRATES[@]}" ; do
             echo "$crate";
-            pushd crates/"$crate";
 
             # Save the `cargo publish` in case we get a non-zero exit
-            cargo_publish;
+            cargo publish -p $crate 2>&1 | tee "$CARGO_OUTPUT_TMP"
             result="$?";
-
-            #echo "PUBLISH STEP HERE"
-            #(exit 101)
 
             # cargo publish exit codes:
             if [[ "$result" != 0 ]];
@@ -60,8 +47,6 @@ function cargo_publish_all() {
             else
                 CRATES_UPLOADED=$((CRATES_UPLOADED+1));
             fi
-
-            popd
         done
     else
         echo "❌ Max number of publish attempts reached"

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -38,7 +38,7 @@ function cargo_publish_all() {
 
             # Save the `cargo publish` in case we get a non-zero exit
             cargo publish -p $crate 2>&1 | tee "$CARGO_OUTPUT_TMP"
-            result="$?";
+            result="${PIPESTATUS[0]}";
 
             # cargo publish exit codes:
             if [[ "$result" != 0 ]];


### PR DESCRIPTION
Existing script seems to fail with current `cargo`

https://github.com/infinyon/k8-api/actions/runs/9958895141/job/27514365611


```
Run ./scripts/publish-crates.sh
+ cargo_publish_all
+ [[ 1 -lt 4 ]]
VERBOSE MODE ON
+ for crate in "${PUBLISH_CRATES[@]}"
+ echo k8-config
k8-config
+ pushd crates/k8-config
./scripts/publish-crates.sh: line 47: pushd: crates/k8-config: No such file or directory
+ cargo_publish
+ cargo publish
+ tee /tmp/tmp.c0qK0CjQR0
error: the `-p` argument must be specified to select a single package to publish
+ return 101
```

Updated script succeeds https://github.com/infinyon/k8-api/actions/runs/9958983399/job/27514677932